### PR TITLE
じゃんけんゲームのコードベースをリファクタリングし、モジュール性とテスト可能性を向上させました。

### DIFF
--- a/src/janken.gleam
+++ b/src/janken.gleam
@@ -35,10 +35,12 @@ fn player_intent() -> PlayerIntent {
     Ok(string) -> {
       case string {
         "quit" | "q" -> Quit
-        "rock" | "r" -> Play(hand.Rock)
-        "paper" | "p" -> Play(hand.Paper)
-        "scissors" | "s" -> Play(hand.Scissors)
-        _ -> Invalid
+        _ -> {
+          case hand.from_string(string) {
+            Ok(h) -> Play(h)
+            Error(_) -> Invalid
+          }
+        }
       }
     }
     Error(_) -> {
@@ -48,26 +50,23 @@ fn player_intent() -> PlayerIntent {
   }
 }
 
+fn play_round(player_hand: hand.Hand) {
+  let computer_hand = computer_hand()
+
+  io.println("Computer hand: " <> hand.to_string(computer_hand))
+  io.println("Your hand: " <> hand.to_string(player_hand))
+
+  play(player_hand, computer_hand)
+  |> outcome.to_string
+  |> io.println
+}
+
 fn game() -> PlayerIntent {
   let intent = player_intent()
   case intent {
-    Play(player_hand) -> {
-      let computer_hand = computer_hand()
-
-      io.println("Computer hand: " <> hand.to_string(computer_hand))
-      io.println("Your hand: " <> hand.to_string(player_hand))
-
-      io.println(
-        play(player_hand, computer_hand)
-        |> outcome.to_string,
-      )
-    }
-    Invalid -> {
-      io.println("Invalid input. Please try again.")
-    }
-    Quit -> {
-      io.println("Thanks for playing!")
-    }
+    Play(player_hand) -> play_round(player_hand)
+    Invalid -> io.println("Invalid input. Please try again.")
+    Quit -> io.println("Thanks for playing!")
   }
   intent
 }

--- a/src/janken/hand.gleam
+++ b/src/janken/hand.gleam
@@ -11,3 +11,12 @@ pub fn to_string(hand: Hand) -> String {
     Scissors -> "Scissors"
   }
 }
+
+pub fn from_string(s: String) -> Result(Hand, Nil) {
+  case s {
+    "rock" | "r" -> Ok(Rock)
+    "paper" | "p" -> Ok(Paper)
+    "scissors" | "s" -> Ok(Scissors)
+    _ -> Error(Nil)
+  }
+}

--- a/test/janken_test.gleam
+++ b/test/janken_test.gleam
@@ -1,6 +1,6 @@
 import gleeunit
 import gleeunit/should
-import janken/hand.{Paper, Rock, Scissors}
+import janken/hand
 import janken/outcome.{Draw, Lose, Win}
 import janken/play
 
@@ -10,48 +10,89 @@ pub fn main() -> Nil {
 
 // Draw cases
 pub fn play_rock_vs_rock_test() {
-  play.play(Rock, Rock)
+  play.play(hand.Rock, hand.Rock)
   |> should.equal(Draw)
 }
 
 pub fn play_paper_vs_paper_test() {
-  play.play(Paper, Paper)
+  play.play(hand.Paper, hand.Paper)
   |> should.equal(Draw)
 }
 
 pub fn play_scissors_vs_scissors_test() {
-  play.play(Scissors, Scissors)
+  play.play(hand.Scissors, hand.Scissors)
   |> should.equal(Draw)
 }
 
 // Win cases
 pub fn play_rock_vs_scissors_test() {
-  play.play(Rock, Scissors)
+  play.play(hand.Rock, hand.Scissors)
   |> should.equal(Win)
 }
 
 pub fn play_paper_vs_rock_test() {
-  play.play(Paper, Rock)
+  play.play(hand.Paper, hand.Rock)
   |> should.equal(Win)
 }
 
 pub fn play_scissors_vs_paper_test() {
-  play.play(Scissors, Paper)
+  play.play(hand.Scissors, hand.Paper)
   |> should.equal(Win)
 }
 
 // Lose cases
 pub fn play_rock_vs_paper_test() {
-  play.play(Rock, Paper)
+  play.play(hand.Rock, hand.Paper)
   |> should.equal(Lose)
 }
 
 pub fn play_paper_vs_scissors_test() {
-  play.play(Paper, Scissors)
+  play.play(hand.Paper, hand.Scissors)
   |> should.equal(Lose)
 }
 
 pub fn play_scissors_vs_rock_test() {
-  play.play(Scissors, Rock)
+  play.play(hand.Scissors, hand.Rock)
   |> should.equal(Lose)
+}
+
+// hand.from_string
+pub fn from_string_rock_test() {
+  hand.from_string("rock")
+  |> should.equal(Ok(hand.Rock))
+}
+
+pub fn from_string_r_test() {
+  hand.from_string("r")
+  |> should.equal(Ok(hand.Rock))
+}
+
+pub fn from_string_paper_test() {
+  hand.from_string("paper")
+  |> should.equal(Ok(hand.Paper))
+}
+
+pub fn from_string_p_test() {
+  hand.from_string("p")
+  |> should.equal(Ok(hand.Paper))
+}
+
+pub fn from_string_scissors_test() {
+  hand.from_string("scissors")
+  |> should.equal(Ok(hand.Scissors))
+}
+
+pub fn from_string_s_test() {
+  hand.from_string("s")
+  |> should.equal(Ok(hand.Scissors))
+}
+
+pub fn from_string_invalid_test() {
+  hand.from_string("invalid")
+  |> should.equal(Error(Nil))
+}
+
+pub fn from_string_empty_test() {
+  hand.from_string("")
+  |> should.equal(Error(Nil))
 }


### PR DESCRIPTION
主な変更点:
- メインの `janken.gleam` ファイルにおいて、ラウンドの実行ロジックを専用の関数に切り出すことで、関心の分離を行いました。
- 文字列から手を解析するロジックを新しい `hand.from_string` 関数に移動し、カプセル化を改善しました。
- 新しい `hand.from_string` 関数に対して、有効な入力と無効な入力の両方をカバーする包括的な単体テストを追加しました。
- `player_intent` 関数を簡素化し、新しい `hand.from_string` 関数を使用するように変更しました。